### PR TITLE
Fix some bugs to make import scores work again for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-socket-security",
     "displayName": "Socket Security",
     "description": "Editor integration with Socket Security",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "private": true,
     "preview": false,
     "categories": [

--- a/src/data/report.ts
+++ b/src/data/report.ts
@@ -113,7 +113,7 @@ export async function activate(context: vscode.ExtensionContext, disposables?: A
     const watchTargets = [
         ...Object.values(supportedFiles.npm),
         ...Object.values(supportedFiles.pypi),
-        ...Object.values(supportedFiles.go)
+        ...Object.values(supportedFiles.golang)
     ].map(info => info.pattern);
 
     addDisposablesTo(
@@ -291,7 +291,7 @@ export async function activate(context: vscode.ExtensionContext, disposables?: A
             ...allPyFiles
         ] = await Promise.all([
             findWorkspaceFiles(`**/${globPatterns.npm.packagejson.pattern}`, pkgJSONCacheKey),
-            findWorkspaceFiles(`**/${globPatterns.go.gomod.pattern}`, goModCacheKey),
+            findWorkspaceFiles(`**/${globPatterns.golang.gomod.pattern}`, goModCacheKey),
             findWorkspaceFiles(`**/${globPatterns.pypi.pipfile.pattern}`, pipfileCacheKey),
             findWorkspaceFiles(`**/${globPatterns.pypi.pyproject.pattern}`, pyprojectCacheKey),
             findWorkspaceFiles(`**/${globPatterns.pypi.requirements.pattern}`, requirementsCacheKey),
@@ -310,9 +310,9 @@ export async function activate(context: vscode.ExtensionContext, disposables?: A
         )).flat().filter(file => pkgJSONParents.has(uriParent(file.uri)))
 
         const goModParents = new Set(goModFiles.map(file => uriParent(file.uri)))
-        const goExtraFilePatterns = Object.keys(globPatterns.go)
+        const goExtraFilePatterns = Object.keys(globPatterns.golang)
             .filter(name => name !== 'gomod')
-            .map(name => globPatterns.go[name])
+            .map(name => globPatterns.golang[name])
 
         const goExtraFiles = (await Promise.all(
             goExtraFilePatterns.map(p => findWorkspaceFiles(`**/${p.pattern}`, hashCacheKey))

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,7 +69,7 @@ export async function activate(context: ExtensionContext) {
     const watchTargets = {
         npm: ['packagejson'],
         pypi: ['pipfile', 'requirements', 'pyproject'],
-        go: ['gomod', 'gosum']
+        golang: ['gomod', 'gosum']
     }
 
     const watchTargetValues = Object.entries(watchTargets).flatMap(([eco, names]) => names.map(name => ({

--- a/src/ui/file.ts
+++ b/src/ui/file.ts
@@ -129,7 +129,7 @@ export function activate(
             return existing.score;
         }
         const score = new Promise<PackageScore>((f, r) => {
-            const req = https.get(`https://socket.dev/api/${eco}/package/scores?name=${pkgName}`);
+            const req = https.get(`https://socket.dev/api/${eco}/package-info/score?name=${pkgName}`);
             function cleanupReq() {
                 try {
                     req.destroy();

--- a/src/ui/go-mod.ts
+++ b/src/ui/go-mod.ts
@@ -42,7 +42,7 @@ async function provideCodeLenses(document: vscode.TextDocument, token: vscode.Ca
 export async function registerCodeLensProvider() {
     const globPatterns = await getGlobPatterns();
     return vscode.languages.registerCodeLensProvider({
-        pattern: `**/${globPatterns.go.gomod.pattern}`,
+        pattern: `**/${globPatterns.golang.gomod.pattern}`,
         scheme: undefined
     }, {
         provideCodeLenses
@@ -52,7 +52,7 @@ export async function registerCodeLensProvider() {
 export async function registerCodeActionsProvider() {
     const patterns = await getGlobPatterns();
     return vscode.languages.registerCodeActionsProvider({
-        pattern: `**/${patterns.go.gomod.pattern}`,
+        pattern: `**/${patterns.golang.gomod.pattern}`,
         scheme: undefined
     }, {
         provideCodeActions

--- a/src/ui/parse-externals.ts
+++ b/src/ui/parse-externals.ts
@@ -509,7 +509,7 @@ export async function parseExternals(doc: Pick<vscode.TextDocument, 'getText' | 
                     });
                 }
             }
-        } else if (micromatch.isMatch(basename, globPatterns.go.gomod.pattern)) {
+        } else if (micromatch.isMatch(basename, globPatterns.golang.gomod.pattern)) {
             const parsed = await parseGoMod(src)
             if (!parsed) return null
 


### PR DESCRIPTION
I also noticed that there are a bunch of uncaught exceptions while typing due to request aborts, but that seems like a more invasive change.

<img width="557" alt="Screenshot 2024-09-12 at 9 38 38 AM" src="https://github.com/user-attachments/assets/6d4c1241-28f3-4835-af4f-e6a9f1cf5de3">
