### PR TITLE
fix(scores): keep worst artifact per PURL in hover popup

### DIFF
--- a/src/ui/purl-alerts-and-scores/manager.ts
+++ b/src/ui/purl-alerts-and-scores/manager.ts
@@ -7,6 +7,7 @@ import { getAPIKey } from '../../auth'
 import { streamPackageScores } from '../../api'
 import type { PackageScoreAndAlerts } from '../../api'
 import { safeDeleteSync } from '@socketsecurity/lib/fs/safe'
+import { worstArtifactsByPurl } from './select-artifacts'
 // if this is updated update lifecycle scripts
 const cacheDir = path.resolve(os.homedir(), '.socket', 'vscode')
 
@@ -155,13 +156,31 @@ export class PURLDataCache {
         const scores = streamPackageScores(apiKey, [...thesePendingUpdates], {
           timeout: this.timeout,
         })
+        // The /v0/purl endpoint can stream MULTIPLE artifacts for the same
+        // input PURL (e.g. a PyPI sdist and wheel of one version) with
+        // different scores and alerts. Buffer them all, then collapse to the
+        // worst-scoring artifact per PURL so a clean artifact can't hide a
+        // dangerous one (SURF-276). See worstArtifactsByPurl.
+        const streamedArtifacts: PackageScoreAndAlerts[] = []
         for await (const scoreAndAlerts of scores) {
           // The timer above may have already bailed these entries; stop
           // consuming once aborted so we don't resurrect stale updates.
           if (controller.signal.aborted) {
             break
           }
-          const inputPurl = scoreAndAlerts.inputPurl
+          streamedArtifacts.push(scoreAndAlerts)
+        }
+        // Collapsing needs the whole stream, so the abort check above cannot
+        // also gate the writes the way it did when each artifact was applied
+        // as it arrived. Re-check here or an aborted batch would resurrect the
+        // entries bailPendingCacheEntries just errored out.
+        if (controller.signal.aborted) {
+          return
+        }
+        // oxlint-disable-next-line socket/prefer-cached-for-loop -- iterating a Map.
+        for (const [inputPurl, scoreAndAlerts] of worstArtifactsByPurl(
+          streamedArtifacts,
+        )) {
           this.#pkgData.get(inputPurl)?.update(scoreAndAlerts)
           thesePendingUpdates.delete(inputPurl)
         }

--- a/src/ui/purl-alerts-and-scores/select-artifacts.ts
+++ b/src/ui/purl-alerts-and-scores/select-artifacts.ts
@@ -1,0 +1,42 @@
+/**
+ * @file Pure artifact-selection logic for the Socket `/v0/purl` response,
+ *   extracted from `manager.ts` so it can be unit-tested without pulling in the
+ *   VSCode runtime. Note: the manager module opens an output channel at import
+ *   time. Only type imports are used here, so importing this file executes no
+ *   VSCode code.
+ */
+
+import type { SimPURL } from '../externals/parse-externals'
+import type { PackageScoreAndAlerts } from './manager'
+
+/**
+ * Collapse the artifacts the `/v0/purl` endpoint streams into a single entry
+ * per input PURL, keeping the WORST-scoring artifact.
+ *
+ * The endpoint returns one entry per artifact, so a single input PURL can yield
+ * several entries (for example a PyPI sdist and a wheel of the same version).
+ * Those artifacts can carry different scores and alerts: a malicious sdist with
+ * a `setup.py` payload can score 0 with a `malware` alert while the wheel of
+ * the same version scores 99 with no alerts. Keeping the entry with the lowest
+ * `score.overall` stops a clean artifact from hiding a dangerous one and makes
+ * the hover popup agree with socket.dev's package headline (SURF-276).
+ *
+ * A missing or non-numeric score sorts last (treated as `Infinity`) so an entry
+ * that actually has a score always wins over one that does not. When two
+ * entries for the same PURL tie, the first one seen is kept.
+ */
+export function worstArtifactsByPurl(
+  entries: readonly PackageScoreAndAlerts[],
+): Map<SimPURL, PackageScoreAndAlerts> {
+  const overallScoreOf = (data: PackageScoreAndAlerts): number =>
+    typeof data?.score?.overall === 'number' ? data.score.overall : Infinity
+  const worstByPurl = new Map<SimPURL, PackageScoreAndAlerts>()
+  for (let i = 0, { length } = entries; i < length; i += 1) {
+    const entry = entries[i]!
+    const prev = worstByPurl.get(entry.inputPurl)
+    if (!prev || overallScoreOf(entry) < overallScoreOf(prev)) {
+      worstByPurl.set(entry.inputPurl, entry)
+    }
+  }
+  return worstByPurl
+}

--- a/test/select-artifacts.test.mts
+++ b/test/select-artifacts.test.mts
@@ -1,0 +1,99 @@
+/**
+ * @file Unit tests for worstArtifactsByPurl (src/ui/purl-alerts-and-scores/
+ *   select-artifacts.ts) — the fix for SURF-276, where the hover popup showed a
+ *   clean score for a package whose sdist was flagged as malware. The
+ *   `/v0/purl` endpoint streams one entry per artifact, so a single PURL can
+ *   return several entries; the popup must surface the worst one, not whichever
+ *   arrives last.
+ */
+
+import { describe, expect, test } from 'vitest'
+
+import { worstArtifactsByPurl } from '../src/ui/purl-alerts-and-scores/select-artifacts'
+
+import type { SimPURL } from '../src/ui/externals/parse-externals'
+import type { PackageScoreAndAlerts } from '../src/ui/purl-alerts-and-scores/manager'
+
+// Build a minimal artifact entry of the shape the /v0/purl endpoint returns.
+// Only the fields worstArtifactsByPurl reads (inputPurl, score.overall) matter;
+// the rest satisfy the type.
+function makeArtifact(
+  inputPurl: SimPURL,
+  overall: number | undefined,
+  extra?: Partial<PackageScoreAndAlerts> | undefined,
+): PackageScoreAndAlerts {
+  return {
+    alerts: [],
+    inputPurl,
+    score: {
+      license: 1,
+      maintenance: 1,
+      overall: overall as number,
+      quality: 1,
+      supplyChain: 1,
+      vulnerability: 1,
+    },
+    type: 'pypi',
+    name: inputPurl.split('/')[1] ?? 'pkg',
+    ...extra,
+  }
+}
+
+describe('worstArtifactsByPurl', () => {
+  const purl = 'pkg:pypi/smscallbomber' as SimPURL
+
+  // The exact SURF-276 shape: /v0/purl returns a malicious sdist (overall 0,
+  // malware alert) and a clean wheel (overall 0.99) for the same PURL. The
+  // popup must show the sdist regardless of stream order.
+  const maliciousSdist = makeArtifact(purl, 0, {
+    alerts: [
+      {
+        action: 'error',
+        type: 'malware',
+        severity: 'critical',
+        props: {},
+      },
+    ],
+  })
+  const cleanWheel = makeArtifact(purl, 0.99)
+
+  test('keeps the malware sdist when the clean wheel is last', () => {
+    const result = worstArtifactsByPurl([maliciousSdist, cleanWheel])
+    expect(result.get(purl)).toBe(maliciousSdist)
+  })
+
+  test('keeps the malware sdist when the clean wheel is first', () => {
+    const result = worstArtifactsByPurl([cleanWheel, maliciousSdist])
+    expect(result.get(purl)).toBe(maliciousSdist)
+  })
+
+  test('returns a single artifact unchanged', () => {
+    const only = makeArtifact(purl, 0.5)
+    const result = worstArtifactsByPurl([only])
+    expect(result.size).toBe(1)
+    expect(result.get(purl)).toBe(only)
+  })
+
+  test('an entry with a real score beats one with a missing score', () => {
+    const scored = makeArtifact(purl, 0.4)
+    const unscored = makeArtifact(purl, undefined)
+    expect(worstArtifactsByPurl([scored, unscored]).get(purl)).toBe(scored)
+    expect(worstArtifactsByPurl([unscored, scored]).get(purl)).toBe(scored)
+  })
+
+  test('keeps each distinct PURL independently', () => {
+    const purlA = 'pkg:pypi/a' as SimPURL
+    const purlB = 'pkg:pypi/b' as SimPURL
+    const aLow = makeArtifact(purlA, 0.1)
+    const aHigh = makeArtifact(purlA, 0.9)
+    const bOnly = makeArtifact(purlB, 0.7)
+    const result = worstArtifactsByPurl([aHigh, bOnly, aLow])
+    expect(result.size).toBe(2)
+    expect(result.get(purlA)).toBe(aLow)
+    expect(result.get(purlB)).toBe(bOnly)
+  })
+
+  test('returns an empty map for no entries', () => {
+    expect(worstArtifactsByPurl([]).size).toBe(0)
+  })
+})


### PR DESCRIPTION
Closes SURF-276.

The Socket hover popup was hiding malware. A customer opened a Python file that depended on `smscallbomber`, and the popup showed a package score of **99** with no malware warning. The Socket research page for the same package showed **40** and flagged it. A developer trusting the popup would have installed a package Socket already knows is malicious.

The cause is that one package version can have more than one artifact — PyPI publishes both a source distribution ("sdist") and a pre-built "wheel" — and the extension was keeping whichever artifact happened to arrive last. For this package the clean wheel arrived after the malicious sdist and overwrote it. The fix keeps the **worst-scoring** artifact per package instead, which is what the website shows, so the popup and the research page now agree.

<details>
<summary><b>Why the wrong artifact won</b> — one line per artifact, and each line overwrote the last</summary>

When the extension needs scores, it asks the Socket API endpoint `POST /v0/purl?alerts=true&compact=false`. That endpoint answers with newline-delimited JSON: **one line per artifact**. A single package version can come back on several lines with different scores and alerts.

The code read those lines in a loop and wrote each one into the cache under the package name. Because every line overwrote the previous one, **the last line won**.

For `smscallbomber@2.7` the API returns two artifacts:

| Artifact | Overall score | Malware alert |
|---|---|---|
| `tar-gz` (sdist — the malware lives in its `setup.py`) | 0 | yes, critical |
| `py3-none-any-whl` (wheel) | 99 | none |

The wheel line arrives last, so it overwrote the sdist, and the popup showed 99 with no malware. The research page instead shows the worst artifact, which is why it showed 40.

</details>

<details>
<summary><b>The change</b> — buffer the stream, then keep the lowest score per package</summary>

Collect all the streamed artifacts first, then keep the **worst-scoring** one per package: the lowest `score.overall`, with an artifact that has no score treated as least-bad so a real score always wins. When two artifacts for the same package tie, the first one seen is kept.

The selection logic is extracted into a small pure function, `worstArtifactsByPurl` in `src/ui/purl-alerts-and-scores/select-artifacts.ts`, so it can be unit-tested without loading the VSCode runtime (the manager module opens an output channel the moment it is imported). `manager.ts` now buffers the streamed lines and calls this function.

</details>

<details>
<summary><b>How the root cause was confirmed</b> — the live endpoint returns exactly the two lines described above</summary>

Querying the live endpoint for `pkg:pypi/smscallbomber` returns exactly two NDJSON lines with the same `inputPurl`, one with `score.overall: 0` and a critical `malware` alert (the sdist) and one with `score.overall: 0.99` and no malware (the wheel). The popup in the customer screenshot matches the wheel line exactly.

</details>

<details>
<summary><b>What is covered by tests</b> — including the ordering case that is the whole bug</summary>

**Ran:** `tsc --noEmit`, `oxlint`, `oxfmt --check`, and the test suite — all pass locally.

`test/select-artifacts.test.mts` covers:
- the SURF-276 case — the malware sdist (score 0) wins over the clean wheel (score 0.99) **regardless of which arrives first**;
- an artifact with a real score beating one with a missing score;
- multiple distinct packages kept independently;
- a single artifact returned unchanged;
- empty input.

</details>

<details>
<summary><b>CI is red for an unrelated reason</b> — a fleet-infrastructure failure that affects every PR in this repo</summary>

The red `Check` / `Test` jobs are a fleet-infrastructure failure in the shared bootstrap step (`setup-and-install`), which runs before any of this code. The same base tree is green on the `main` push run but red on `pull_request` runs; it affects every PR in the repo, not this change. Flagged to the team separately.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how security scores and alerts are chosen for the hover UI—a trust-critical path—but the logic is isolated, well-tested, and aligns display with socket.dev’s worst-artifact behavior.
> 
> **Overview**
> Fixes **SURF-276**: the VS Code hover could show a high score and no malware warning when `/v0/purl` streamed multiple artifacts for one PURL (e.g. malicious PyPI sdist vs clean wheel), because **the last streamed line overwrote the cache**.
> 
> The manager now **buffers** the full stream, then applies **one entry per input PURL** via `worstArtifactsByPurl` (lowest `score.overall`; missing scores treated as least bad). Abort handling is adjusted so a timed-out batch does not write after `bailPendingCacheEntries` has already errored entries.
> 
> Selection logic lives in `select-artifacts.ts` for unit tests without loading the VS Code manager; tests cover stream order, ties, multiple PURLs, and unscored artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d789459c36a9b5ef457997b4a9ae999a9dc03318. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->