### PR TITLE
fix(auth): create settings dir before watching it

### DIFF
--- a/src/auth-paths.ts
+++ b/src/auth-paths.ts
@@ -1,0 +1,66 @@
+/**
+ * @file Pure path derivation for the auth settings file, split out of `auth.ts`
+ *   so it can be unit-tested without pulling in the VSCode runtime (`auth.ts`
+ *   imports `vscode`, which only resolves inside the extension host). This file
+ *   imports only `node:path`.
+ */
+
+import { mkdirSync } from 'node:fs'
+import path from 'node:path'
+
+/**
+ * Ensure `dirPath` exists, creating it (and any missing parents) if needed.
+ *
+ * This is the SURF-111 fix: the settings directory does not exist until the
+ * user first logs in, and pointing a VSCode file-system watcher at a missing
+ * directory makes VSCode repeatedly log that it is watching a non-existent
+ * folder. Creating it first keeps the watcher's base present.
+ *
+ * `mkdirSync` with `recursive: true` is idempotent — it is a no-op when the
+ * directory already exists. Any error (for example a read-only filesystem) is
+ * swallowed so this can never break extension activation. Uses `node:fs`
+ * directly (like the cache directory in the scores manager) so the behavior is
+ * unit-testable against a real temporary directory; for the local data-home
+ * path this is equivalent to `vscode.workspace.fs.createDirectory`.
+ */
+export function ensureDirectoryExists(dirPath: string): void {
+  try {
+    mkdirSync(dirPath, { recursive: true })
+  } catch {}
+}
+
+/**
+ * Resolve the per-user data directory Socket stores its settings file under.
+ * This is the base whose `socket` subdirectory the extension both writes to (on
+ * login) and watches — the directory that was missing on a fresh install and
+ * produced the "searching for non-existent folder" watcher error (SURF-111).
+ *
+ * On Windows the value comes from `%LOCALAPPDATA%`, and its absence is fatal
+ * (there is no sensible fallback). Elsewhere it comes from `$XDG_DATA_HOME`,
+ * falling back to `~/Library/Application Support` on macOS and `~/.local/share`
+ * on other platforms.
+ *
+ * Pure: takes the platform, environment, and home directory as arguments so the
+ * cross-platform path derivation can be unit-tested without touching the real
+ * process.
+ */
+export function resolveDataHome(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+  homedir: string,
+): string {
+  const dataHome =
+    platform === 'win32' ? env['LOCALAPPDATA'] : env['XDG_DATA_HOME']
+  if (dataHome) {
+    return dataHome
+  }
+  if (platform === 'win32') {
+    throw new Error('missing %LOCALAPPDATA%')
+  }
+  return path.join(
+    homedir,
+    ...(platform === 'darwin'
+      ? ['Library', 'Application Support']
+      : ['.local', 'share']),
+  )
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -8,6 +8,7 @@ import { once } from 'node:events'
 import type { IncomingMessage } from 'node:http'
 import { text } from 'node:stream/consumers'
 import crypto from 'node:crypto'
+import { ensureDirectoryExists, resolveDataHome } from './auth-paths'
 export type APIConfig = {
   apiKey: string
 }
@@ -34,23 +35,7 @@ export async function activate(
 ) {
   //#region file path/watching
   // responsible for watching files to know when to sync from disk
-  let dataHome =
-    process.platform === 'win32'
-      ? process.env['LOCALAPPDATA']
-      : process.env['XDG_DATA_HOME']
-
-  if (!dataHome) {
-    if (process.platform === 'win32') {
-      throw new Error('missing %LOCALAPPDATA%')
-    }
-    const home = os.homedir()
-    dataHome = path.join(
-      home,
-      ...(process.platform === 'darwin'
-        ? ['Library', 'Application Support']
-        : ['.local', 'share']),
-    )
-  }
+  const dataHome = resolveDataHome(process.platform, process.env, os.homedir())
   const pleaseLoginStatusBar = vscode.window.createStatusBarItem(
     vscode.StatusBarAlignment.Left,
     100,
@@ -75,6 +60,12 @@ export async function activate(
   const diskSessionsChanges =
     new vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>()
 
+  // The settings directory (e.g. ~/.local/share/socket, %LOCALAPPDATA%\socket)
+  // does not exist until the user first logs in and we persist a token.
+  // Pointing a file-system watcher at a missing base directory makes VSCode
+  // repeatedly log that it is watching a non-existent folder (SURF-111). Ensure
+  // the directory exists first (idempotent, and never throws).
+  ensureDirectoryExists(path.dirname(settingsPath))
   const watcher = vscode.workspace.createFileSystemWatcher(
     new vscode.RelativePattern(
       path.dirname(settingsPath),

--- a/test/auth-paths.test.mts
+++ b/test/auth-paths.test.mts
@@ -1,0 +1,104 @@
+/**
+ * @file Unit tests for src/auth-paths.ts — the SURF-111 fix. Before the fix,
+ *   the extension pointed a file watcher at the settings directory, which does
+ *   not exist until first login, so VSCode logged that it was "searching for a
+ *   non-existent folder". ensureDirectoryExists now creates that directory
+ *   first, and resolveDataHome computes which directory that is per platform.
+ */
+
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { safeDelete } from '@socketsecurity/lib-stable/fs/safe'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+
+import { ensureDirectoryExists, resolveDataHome } from '../src/auth-paths'
+
+describe('ensureDirectoryExists', () => {
+  let tmpRoot: string
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(path.join(os.tmpdir(), 'socket-auth-paths-'))
+  })
+
+  afterEach(async () => {
+    await safeDelete(tmpRoot)
+  })
+
+  test('creates the directory (and missing parents) when absent', () => {
+    // The real SURF-111 shape: <dataHome>/socket where neither exists yet.
+    const dir = path.join(tmpRoot, 'dataHome', 'socket')
+    expect(existsSync(dir)).toBe(false)
+    ensureDirectoryExists(dir)
+    expect(existsSync(dir)).toBe(true)
+  })
+
+  test('is a no-op and does not throw when the directory already exists', () => {
+    const dir = path.join(tmpRoot, 'already-here')
+    ensureDirectoryExists(dir)
+    // Put a file inside, then call again: the directory and its contents must
+    // survive (recursive mkdir does not clear an existing directory).
+    const marker = path.join(dir, 'marker.txt')
+    writeFileSync(marker, 'keep me')
+    expect(() => ensureDirectoryExists(dir)).not.toThrow()
+    expect(existsSync(dir)).toBe(true)
+    expect(existsSync(marker)).toBe(true)
+  })
+
+  test('does not throw when creation fails (path under a file)', () => {
+    // Using a regular file as a parent makes mkdir fail (ENOTDIR); the helper
+    // must swallow it so activation can never be broken by the filesystem.
+    const filePath = path.join(tmpRoot, 'a-file')
+    writeFileSync(filePath, 'not a directory')
+    const doomed = path.join(filePath, 'child')
+    expect(() => ensureDirectoryExists(doomed)).not.toThrow()
+    expect(existsSync(doomed)).toBe(false)
+  })
+})
+
+describe('resolveDataHome', () => {
+  const HOME = '/home/tester'
+
+  test('uses %LOCALAPPDATA% on Windows', () => {
+    expect(
+      resolveDataHome(
+        'win32',
+        { LOCALAPPDATA: 'C:\\Users\\t\\AppData\\Local' },
+        HOME,
+      ),
+    ).toBe('C:\\Users\\t\\AppData\\Local')
+  })
+
+  test('throws on Windows when %LOCALAPPDATA% is missing', () => {
+    expect(() => resolveDataHome('win32', {}, HOME)).toThrow('%LOCALAPPDATA%')
+  })
+
+  test('uses $XDG_DATA_HOME when set on non-Windows', () => {
+    expect(
+      resolveDataHome('linux', { XDG_DATA_HOME: '/custom/xdg' }, HOME),
+    ).toBe('/custom/xdg')
+  })
+
+  test('falls back to ~/Library/Application Support on macOS', () => {
+    expect(resolveDataHome('darwin', {}, HOME)).toBe(
+      path.join(HOME, 'Library', 'Application Support'),
+    )
+  })
+
+  test('falls back to ~/.local/share on other platforms', () => {
+    expect(resolveDataHome('linux', {}, HOME)).toBe(
+      path.join(HOME, '.local', 'share'),
+    )
+  })
+
+  test('ignores XDG_DATA_HOME on Windows (reads LOCALAPPDATA)', () => {
+    expect(
+      resolveDataHome(
+        'win32',
+        { LOCALAPPDATA: 'C:\\local', XDG_DATA_HOME: '/ignored' },
+        HOME,
+      ),
+    ).toBe('C:\\local')
+  })
+})


### PR DESCRIPTION
Closes SURF-111 ("VSCode is searching for non-existent folder").

On a fresh install of the Socket extension, VSCode logs errors saying it is watching a folder that does not exist. The folder is where the extension saves your API token, and it is only created the first time you log in — but the extension starts watching it the moment it activates, before that folder has ever been created. So every new user gets watcher errors in their log until they log in.

The fix is one line of intent: create the directory (recursively, ignoring any error) right before creating the watcher, so the watcher always points at something real.

<details>
<summary><b>Why it happened</b> — the watcher is set up at activation, the folder is created at first login</summary>

During activation the extension sets up a file watcher so it can react when the user's saved API token changes on disk. The token is stored at `<dataHome>/socket/settings`, and the watcher is pointed at the folder that contains it, `<dataHome>/socket`.

That folder is only created the first time the user logs in and a token is written. Before that first login the folder does not exist, so VSCode's watcher keeps reporting that it is watching a missing directory.

</details>

<details>
<summary><b>Why creating it early is safe</b> — idempotent, never throws, and the same location the extension already writes to</summary>

The extension already writes the token to this exact location on login — this only makes the folder a moment earlier. `mkdirSync` with `recursive: true` is a no-op when the folder is already there, and any error is swallowed, so this cannot break activation on a read-only or unusual filesystem.

It uses `node:fs` (like the scores manager already does for its cache directory) so the behavior is testable with real files; for the local data-home path this is equivalent to the previous `vscode.workspace.fs.createDirectory` call.

</details>

<details>
<summary><b>What is covered by tests</b> — both pieces extracted into a pure module, 9 cases</summary>

**Ran:** `tsc --noEmit`, `oxlint`, `oxfmt --check`, and the test suite — all pass locally.

The fix's two pieces are both extracted into `src/auth-paths.ts` and unit-tested in `test/auth-paths.test.mts` (9 cases):

- `ensureDirectoryExists` — the create-before-watch behavior itself, tested against a real temporary directory:
  - creates the directory and any missing parents when absent (the real `<dataHome>/socket` shape);
  - is a no-op that preserves existing contents when the directory already exists;
  - swallows a failure (a path underneath a regular file) without throwing.
- `resolveDataHome` — the cross-platform derivation of which directory that is: Windows `%LOCALAPPDATA%`, Windows throwing when it is missing, `$XDG_DATA_HOME`, and the macOS and Linux fallbacks.

</details>

<details>
<summary><b>The ticket text had drifted</b> — this fixes the defect in the title, not the stale scope discussion</summary>

The ticket's written description had drifted into questions about API-token scopes and the endpoints `npm/score` and `npm/pkg/ver/issues`. Those endpoints belong to the old (pre-rewrite) extension; the current extension calls `/v0/purl` instead. This PR fixes the reproducible defect named in the ticket title (the missing folder), not the stale scope discussion.

</details>

<details>
<summary><b>CI is red for an unrelated reason</b> — a fleet-infrastructure failure that affects every PR in this repo</summary>

The red `Check` / `Test` jobs are a fleet-infrastructure failure in the shared bootstrap step (`setup-and-install`), which runs before any of this code. The same base tree is green on the `main` push run but red on `pull_request` runs; it affects every PR in the repo, not this change. Flagged to the team separately.

</details>
