### PR TITLE
fix(ci): use fleet setup-and-install instead of npm ci in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,8 +28,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 (2026-05-15)
         with:
           persist-credentials: false
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0 (2026-05-15)
-      - run: npm ci
+      - uses: ./.github/actions/fleet/setup-and-install
+        with:
+          socket-api-token: ${{ secrets.SOCKET_API_TOKEN_FOR_CLI_AND_SFW }}
       - name: Publish to Open VSX Registry
         if: success() || failure()
         uses: ./.github/actions/repo/publish-vscode-extension


### PR DESCRIPTION
## Defect

`.github/workflows/publish.yml` runs `npm ci` in a pnpm-locked repo.

## Failure mode

`npm ci` requires `package-lock.json`; this repo only has `pnpm-lock.yaml`, and `devEngines.packageManager` pins pnpm with `onFail: "error"`. The install step fails on every tag push, so the marketplace/OpenVSX publish path never runs as written.

## Fix

Replace the bare `actions/setup-node` + `npm ci` pair with the repo's own fleet composite, `./.github/actions/fleet/setup-and-install`, invoked exactly as the sibling `ci.yml` invokes it (including `socket-api-token`). No workflow step invokes `npm run` scripts, so nothing else needed conversion; the publish/release steps already use local composites.

## Provenance

Found by a fleet-wide code-as-law audit dated 2026-07-28.

## Follow-ups deliberately NOT done here

- The `publish-vscode-extension` composite still packages via `npx --yes @vscode/vsce` internally (vendored from socket-registry); aligning that with the pnpm posture is upstream re-vendor work.
- ci.yml's workflow-level FLEET_ENV telemetry knobs were not copied over, since this workflow does not run `check --all`.
