### PR TITLE
chore(fleet): wire the prune:backups and prune:caches scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "lockstep:emit-schema": "node scripts/fleet/lockstep-emit-schema.mts",
     "package-for-vscode": "vsce package --no-dependencies",
     "prepare": "node scripts/fleet/install-git-hooks.mts && node scripts/fleet/prepare.mts",
+    "prune:backups": "node scripts/fleet/prune-backup-branches.mts",
+    "prune:caches": "node scripts/fleet/prune-actions-caches.mts",
     "security": "node scripts/fleet/security.mts",
     "test": "node scripts/fleet/test.mts",
     "test:fuzz": "node scripts/repo/fuzz.mts",


### PR DESCRIPTION
Our shared template already ships two maintenance tools into this repo, but `package.json` never got the entries that run them. Both files sit on disk at `scripts/fleet/prune-backup-branches.mts` and `scripts/fleet/prune-actions-caches.mts`, and neither was reachable through `pnpm run`. This adds the two missing lines.

This is not a cosmetic gap. The cache tool is the one that matters: this repo is currently holding **5.14 GB of GitHub Actions cache with 9 entries over the keep budget**. GitHub caps a repo at 10 GB and silently evicts the oldest entries past that, so the caches CI restores most often get dropped and jobs quietly rebuild cold while still reporting green.

<details>
<summary><b>How this was found</b> — our shared converge check named both scripts</summary>

Running the shared scaffolding check against this repo reported exactly two findings, and nothing else:

```
missing_recommended_script | Missing recommended script: prune-backups
missing_recommended_script | Missing recommended script: prune-caches
```

With the two entries wired, that check reports none. Worth noting this repo was already the most converged of the ones sampled — 2 findings against 3 apiece for the sibling repos checked, which are also missing these same scripts. So this is a shared wiring gap that happens to be getting fixed here first.

</details>

<details>
<summary><b>Why the names use a colon</b> — we namespace with <code>:</code>, and the shared manifest was renamed to match</summary>

Every other namespaced script in this repo already uses a colon: `setup:brew`, `setup:go`, `check:paths`, `lockstep:emit-schema`, `weekly-update:ci`, `format:check`. The shared manifest was the outlier, listing these two with hyphens.

That manifest is what the converge check matches against, so the rename had to happen there first or this repo would have gone straight back to reporting both scripts missing. The rename has landed upstream and covers the recommended-scripts manifest, the template's own `package.json`, a doc comment in both mirrors, and the check's test fixture.

</details>

<details>
<summary><b>Verification</b> — the wiring was exercised, not just added</summary>

**Ran.** `pnpm run prune:caches --dry-run` resolves and does real work, reporting 105 caches totalling 5.14 GB against the 10 GB ceiling and naming the 9 entries it would remove. `pnpm run prune:backups` runs read-only by default and reported the current backup ref as kept. Full `node scripts/fleet/test.mts --all` passes at 95 tests, and `pnpm run build` exits 0.

**Did not run.** `prune:caches` without `--dry-run`. That flag is opt-in, meaning a bare run deletes, so pruning the 9 entries is left as a deliberate decision rather than a side effect of this PR.

**Not changed.** Only `package.json`, and only two added lines. No script bodies, no config, no source.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Package.json script aliases only; no runtime, auth, or extension behavior changes.
> 
> **Overview**
> Adds **`prune:backups`** and **`prune:caches`** to `package.json` so existing fleet maintenance entrypoints at `scripts/fleet/prune-backup-branches.mts` and `scripts/fleet/prune-actions-caches.mts` are reachable via `pnpm run`, matching the colon naming used elsewhere (`setup:brew`, `lockstep:emit-schema`, etc.).
> 
> No script bodies or config change—only two wiring lines so converge checks and operators can run backup-branch and GitHub Actions cache pruning without invoking `node` paths directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74dc421f14df1ce5c19b5eac09b6aaf63de2fd68. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->