### PR TITLE
test: use replaceAll for the bracket strip in the glob fuzz alphabet

### DIFF
--- a/test/glob-patterns.test.mts
+++ b/test/glob-patterns.test.mts
@@ -134,7 +134,7 @@ describe('data/glob-patterns caseDesensitize (fuzz)', () => {
       .array(
         fc.constantFrom(
           ...LETTERS.split(''),
-          ...NON_LETTER_CHARS.replace(']', '').split(''),
+          ...NON_LETTER_CHARS.replaceAll(']', '').split(''),
         ),
         {
           minLength: 1,


### PR DESCRIPTION
This clears CodeQL alert #18 (`js/incomplete-sanitization`) on this repo. It is a **false positive**, and the change has **zero effect on behaviour** — no vulnerability existed and none is being fixed. The point is noise reduction: a scanner list with a permanent known-benign entry in it slowly trains everyone to skim past real findings, so it is worth spending one character to empty the list.

The one-line change is in a test file, swapping `.replace(']', '')` for `.replaceAll(']', '')`.

<details>
<summary><b>Why the alert is a false positive</b> — the constant being stripped contains no <code>]</code> at all, so the strip never runs</summary>

CodeQL's rule fires whenever it sees `String.prototype.replace` called with a plain string argument, because that form only ever removes the *first* match. Its reasoning is that if you are stripping a dangerous character, stripping only the first one leaves the rest behind.

Here that reasoning does not apply, because there is nothing to strip. The value being cleaned is a fixed constant declared a hundred lines above:

```js
const NON_LETTER_CHARS = '0123456789 .-_/!@#%={}(),'
```

Count the `]` characters in that string: there are zero. The call removes the first occurrence of a character that never occurs, so it returns the constant unchanged. There is no "rest" for the incomplete strip to leave behind, and no input reaches this code from anywhere — it is a literal in the test file.

</details>

<details>
<summary><b>Why keep the strip instead of deleting it</b> — it is a live guard on a generated <code>[...]</code> character class</summary>

The natural reaction is to delete a call that provably does nothing. That would be the wrong call here, because the strip is not dead weight — it is a guard that protects a real invariant, and it is currently satisfied.

The surrounding test builds a glob character group by wrapping generated characters in brackets:

```js
const group = `[${inner}]`
```

If `NON_LETTER_CHARS` ever gained a `]`, the fuzzer could pick it, `inner` would contain a `]`, and the generated group would close early — producing a malformed pattern and a confusing test failure that has nothing to do with the code under test. The strip exists so that cannot happen. Deleting it would remove that protection to satisfy a scanner, which is backwards.

So `replaceAll` is the smallest change that satisfies the scanner while preserving the guard's intent. It is strictly more correct than `replace` for this job (it would strip *all* brackets, not just one, if any ever appeared), and it is identical in behaviour today.

</details>

<details>
<summary><b>Verification</b> — both full gates were run green, and the fix was matched against the alert's own file and line</summary>

**Ran:**

- `node scripts/fleet/test.mts --all` — exit `0`, 103 tests passed across 12 files. Same count as before the change, which is the expected result for a no-op.
- `node scripts/fleet/lint.mts --all` — exit `0`, 215 files formatted correctly, oxlint clean.
- Pre-push validation (security checks, full lint, type check) — passed.
- Confirmed via the code-scanning API that alert #18 points at `test/glob-patterns.test.mts` line 137, which is exactly the line this PR changes. Its message is "This replaces only the first occurrence of `\]`."
- Read `NON_LETTER_CHARS` directly to confirm it contains no `]`, rather than taking that on trust.

**Did not run:**

- A fresh CodeQL scan locally. The alert should close on the next scan of `main` after merge; if it does not, that is worth a follow-up, but the code change is independently correct either way.
- Anything touching runtime or extension behaviour, because this only changes a test fixture's alphabet and cannot affect shipped code.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change in a test fixture; no runtime, security, or data-path impact.
> 
> **Overview**
> In **`test/glob-patterns.test.mts`**, the fuzz alphabet for the “preserves an existing character group verbatim” test now uses **`replaceAll(']', '')`** instead of **`replace(']', '')`** when preparing **`NON_LETTER_CHARS`** for **`constantFrom`**.
> 
> That keeps the intent of excluding **`]`** from generated **`[...]`** group inners (so fuzz patterns stay well-formed) while satisfying CodeQL’s incomplete-sanitization rule. **`NON_LETTER_CHARS`** still has no **`]`** today, so test behaviour is unchanged; no production code is touched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d6b78ff05736aaac071a2bbb2e8973852752093. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->